### PR TITLE
feat(473): Add alwaysRun flag to all bookend steps

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,8 @@ class Bookend extends BookendInterface {
     getSetupCommands(o) {
         return Promise.all(this.setupList.map(m => m.obj.getSetupCommand(o).then(command => ({
             name: `sd-setup-${m.name}`,
-            command
+            command,
+            alwaysRun: true
         }))));
     }
 
@@ -119,7 +120,8 @@ class Bookend extends BookendInterface {
     getTeardownCommands(o) {
         return Promise.all(this.teardownList.map(m => m.obj.getTeardownCommand(o).then(command => ({
             name: `sd-teardown-${m.name}`,
-            command
+            command,
+            alwaysRun: true
         }))));
     }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -126,11 +126,13 @@ describe('bookend', () => {
                 assert.deepEqual(commands, [
                     {
                         name: 'sd-setup-greeting',
-                        command: 'echo "hello"'
+                        command: 'echo "hello"',
+                        alwaysRun: true
                     },
                     {
                         name: 'sd-setup-planet',
-                        command: 'echo "world"'
+                        command: 'echo "world"',
+                        alwaysRun: true
                     }
                 ]);
             });
@@ -143,15 +145,18 @@ describe('bookend', () => {
                 assert.deepEqual(commands, [
                     {
                         name: 'sd-setup-greeting',
-                        command: 'echo "hello"'
+                        command: 'echo "hello"',
+                        alwaysRun: true
                     },
                     {
                         name: 'sd-setup-sample',
-                        command: 'echo "llama"'
+                        command: 'echo "llama"',
+                        alwaysRun: true
                     },
                     {
                         name: 'sd-setup-planet',
-                        command: 'echo "world"'
+                        command: 'echo "world"',
+                        alwaysRun: true
                     }
                 ]);
             });
@@ -166,7 +171,8 @@ describe('bookend', () => {
                 assert.deepEqual(commands, [
                     {
                         name: 'sd-setup-sample2',
-                        command: 'echo "bar"'
+                        command: 'echo "bar"',
+                        alwaysRun: true
                     }
                 ]);
             });
@@ -181,11 +187,13 @@ describe('bookend', () => {
                 assert.deepEqual(commands, [
                     {
                         name: 'sd-teardown-greeting',
-                        command: 'echo "goodbye"'
+                        command: 'echo "goodbye"',
+                        alwaysRun: true
                     },
                     {
                         name: 'sd-teardown-planet',
-                        command: 'echo "mars"'
+                        command: 'echo "mars"',
+                        alwaysRun: true
                     }
                 ]);
             });
@@ -198,15 +206,18 @@ describe('bookend', () => {
                 assert.deepEqual(commands, [
                     {
                         name: 'sd-teardown-greeting',
-                        command: 'echo "goodbye"'
+                        command: 'echo "goodbye"',
+                        alwaysRun: true
                     },
                     {
                         name: 'sd-teardown-sample',
-                        command: 'echo "penguin"'
+                        command: 'echo "penguin"',
+                        alwaysRun: true
                     },
                     {
                         name: 'sd-teardown-planet',
-                        command: 'echo "mars"'
+                        command: 'echo "mars"',
+                        alwaysRun: true
                     }
                 ]);
             });


### PR DESCRIPTION
All bookend steps will automatically be given the `alwaysRun` flag, so that the launcher will know to run them no matter what, regardless of the state of other steps.

Blocked By: screwdriver-cd/data-schema#119 and https://github.com/screwdriver-cd/models/pull/155

Related: https://github.com/screwdriver-cd/screwdriver/issues/473