### PR TITLE
feat(467): Support bookend alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ const b = new Bookend(
      */
     [ 'sample', { name: 'my-bookend', config: { foo: 'bar' } }],
     // Provide a list of plugins for teardown. format is the same as setup
-    [ 'sample', { name: 'my-bookend', config: { foo: 'bar' } }]
+    [ 'sample', { name: 'my-bookend', config: { foo: 'bar' } }],
+    // You can specify an alias for bookends
+    [ 'sample', { name: 'my-bookend-module-with-long-name', alias: 'my-bookend', config: { foo: 'bar' } }]
 );
 
 // Get the setup commands [ { name: 'setup-sample', command: '...' }, { name: 'setup-my-bookend', command: '...' } ] given the models and configuration for the pipeline, job, and build

--- a/index.js
+++ b/index.js
@@ -48,10 +48,8 @@ function initializeBookend(defaultModules, list) {
             name = m;
             alias = m;
         } else {
-            // Use the first key as a module name if name is not set
-            // to support the format: { moduleName: moduleAlias }
-            name = m.name || Object.keys(m)[0];
-            alias = m[name] || name;
+            name = m.name;
+            alias = m.alias || name;
         }
 
         if (defaultModules[name]) {

--- a/index.js
+++ b/index.js
@@ -14,8 +14,11 @@ function loadModule(config) {
     if (typeof c === 'string') {
         c = {
             name: c,
+            alias: c,
             config: {}
         };
+    } else if (!c.alias) {
+        c.alias = c.name;
     }
 
     try {
@@ -23,7 +26,7 @@ function loadModule(config) {
 
         return {
             obj: new Obj(c.config),
-            name: c.name
+            name: c.alias
         };
     } catch (e) {
         throw new Error(`Could not initialize bookend plugin "${c.name}": ${e.message}`);
@@ -38,14 +41,31 @@ function loadModule(config) {
  */
 function initializeBookend(defaultModules, list) {
     return list.map((m) => {
-        if (typeof m === 'string' && defaultModules[m]) {
+        let name;
+        let alias;
+
+        if (typeof m === 'string') {
+            name = m;
+            alias = m;
+        } else {
+            // Use the first key as a module name if name is not set
+            // to support the format: { moduleName: moduleAlias }
+            name = m.name || Object.keys(m)[0];
+            alias = m[name] || name;
+        }
+
+        if (defaultModules[name]) {
             return {
-                obj: defaultModules[m],
-                name: m
+                obj: defaultModules[name],
+                name: alias
             };
         }
 
-        return loadModule(m);
+        return loadModule({
+            name,
+            alias,
+            config: m.config || {}
+        });
     });
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -171,6 +171,31 @@ describe('bookend', () => {
                 ]);
             });
         });
+
+        it('should get a list of commands with aliases', () => {
+            const b = new Bookend(defaultModules, [
+                { greeting: 'foo' },
+                { sample: 'bar' },
+                { planet: 'baz' }
+            ], []);
+
+            return b.getSetupCommands().then((commands) => {
+                assert.deepEqual(commands, [
+                    {
+                        name: 'sd-setup-foo',
+                        command: 'echo "hello"'
+                    },
+                    {
+                        name: 'sd-setup-bar',
+                        command: 'echo "llama"'
+                    },
+                    {
+                        name: 'sd-setup-baz',
+                        command: 'echo "world"'
+                    }
+                ]);
+            });
+        });
     });
 
     describe('getTeardownCommands', () => {
@@ -206,6 +231,31 @@ describe('bookend', () => {
                     },
                     {
                         name: 'sd-teardown-planet',
+                        command: 'echo "mars"'
+                    }
+                ]);
+            });
+        });
+
+        it('should get a list of commands with aliases', () => {
+            const b = new Bookend(defaultModules, [], [
+                { greeting: 'foo' },
+                { sample: 'bar' },
+                { planet: 'baz' }
+            ]);
+
+            return b.getTeardownCommands().then((commands) => {
+                assert.deepEqual(commands, [
+                    {
+                        name: 'sd-teardown-foo',
+                        command: 'echo "goodbye"'
+                    },
+                    {
+                        name: 'sd-teardown-bar',
+                        command: 'echo "penguin"'
+                    },
+                    {
+                        name: 'sd-teardown-baz',
                         command: 'echo "mars"'
                     }
                 ]);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -174,9 +174,9 @@ describe('bookend', () => {
 
         it('should get a list of commands with aliases', () => {
             const b = new Bookend(defaultModules, [
-                { greeting: 'foo' },
-                { sample: 'bar' },
-                { planet: 'baz' }
+                { name: 'greeting', alias: 'foo' },
+                { name: 'sample', alias: 'bar' },
+                { name: 'planet', alias: 'baz' }
             ], []);
 
             return b.getSetupCommands().then((commands) => {
@@ -239,9 +239,9 @@ describe('bookend', () => {
 
         it('should get a list of commands with aliases', () => {
             const b = new Bookend(defaultModules, [], [
-                { greeting: 'foo' },
-                { sample: 'bar' },
-                { planet: 'baz' }
+                { name: 'greeting', alias: 'foo' },
+                { name: 'sample', alias: 'bar' },
+                { name: 'planet', alias: 'baz' }
             ]);
 
             return b.getTeardownCommands().then((commands) => {


### PR DESCRIPTION
I added the alias feature to build bookend. screwdriver-cd/screwdriver#467

Currently a build bookend may not work the case it is published as scoped package because a step name would be `sd-setup-@myscope/foobar-bookend`. Users can probably use scoped packages by this change.