### PR TITLE
fix: use semantic-release template

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -11,9 +11,7 @@ jobs:
             - test: npm test
 
     publish:
-        steps:
-            - install: npm install semantic-release
-            - publish: npm run semantic-release
+        template: screwdriver-cd/semantic-release 
         secrets:
             # Publishing to NPM
             - NPM_TOKEN


### PR DESCRIPTION
Publish job is failing because of semantic release.
https://cd.screwdriver.cd/pipelines/29/builds/11215

This PR fix this by using `semantic-release` template. the same as https://github.com/screwdriver-cd/scm-github/pull/71