### PR TITLE
[1] feat(2763): execute different bookends on different build cluster. BREAKING CHANGE: change constructor arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,8 +99,11 @@ class Bookend extends BookendInterface {
     /**
      * Constructs the list of modules used by bookends
      * @constructor
-     * @param {Object}  defaultModules      key->instantiated plugin for default plugins provided by screwdriver-cd
-     * @param {Object}  config              Object keyed by cluster name with setup/teardown bookend in each.
+     * @param {Object}  defaultModules            key->instantiated plugin for default plugins provided by screwdriver-cd
+     * @param {Object}  config                    Object keyed by cluster name with setup/teardown bookend in each.
+     * @param {Object}  config.default            Default setup/teardown bookend config
+     * @param {Array}   config.default.setup      Default list of module names, or objects { name, config } for instantiation to use in sd-setup
+     * @param {Array}   config.default.teardown   Default list of module names, or objects { name, config } for instantiation to use in sd-teardown
      */
     constructor(defaultModules, config) {
         super();

--- a/index.js
+++ b/index.js
@@ -122,11 +122,11 @@ class Bookend extends BookendInterface {
     /**
      * Gives the commands needed for setup before the build starts
      * @method getSetupCommands
-     * @param  {Object}         o           Information about the environment for setup
-     * @param  {PipelineModel}  o.pipeline  Pipeline model for the build
-     * @param  {JobModel}       o.job       Job model for the build
-     * @param  {Object}         o.build     Build configuration for the build (before creation)
-     * @param  {String}         clusterName Cluster name
+     * @param  {Object}         o             Information about the environment for setup
+     * @param  {PipelineModel}  o.pipeline    Pipeline model for the build
+     * @param  {JobModel}       o.job         Job model for the build
+     * @param  {Object}         o.build       Build configuration for the build (before creation)
+     * @param  {String}         [clusterName] Cluster name
      * @return {Promise}
      */
     getSetupCommands(o, clusterName = 'default') {
@@ -145,11 +145,11 @@ class Bookend extends BookendInterface {
     /**
      * Gives the commands needed for teardown after the build completes
      * @method getTeardownCommands
-     * @param  {Object}         o           Information about the environment for setup
-     * @param  {PipelineModel}  o.pipeline  Pipeline model for the build
-     * @param  {JobModel}       o.job       Job model for the build
-     * @param  {Object}         o.build     Build configuration for the build (before creation)
-     * @param  {String}         clusterName Cluster name
+     * @param  {Object}         o             Information about the environment for setup
+     * @param  {PipelineModel}  o.pipeline    Pipeline model for the build
+     * @param  {JobModel}       o.job         Job model for the build
+     * @param  {Object}         o.build       Build configuration for the build (before creation)
+     * @param  {String}         [clusterName] Cluster name
      * @return {Promise}
      */
     getTeardownCommands(o, clusterName = 'default') {

--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ class Bookend extends BookendInterface {
      * @param  {String}         clusterName Cluster name
      * @return {Promise}
      */
-    getTeardownCommands(o, clusterName) {
+    getTeardownCommands(o, clusterName = 'default') {
         const bookends = this.bookends[clusterName] || this.bookends.default;
 
         return Promise.all(

--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ class Bookend extends BookendInterface {
      * Constructs the list of modules used by bookends
      * @constructor
      * @param {Object}  defaultModules            key->instantiated plugin for default plugins provided by screwdriver-cd
-     * @param {Object}  config                    Object keyed by cluster name with setup/teardown bookend in each.
+     * @param {Object}  config                    Object keyed by cluster name with value setup/teardown bookend.
      * @param {Object}  config.default            Default setup/teardown bookend config
      * @param {Array}   config.default.setup      Default list of module names, or objects { name, config } for instantiation to use in sd-setup
      * @param {Array}   config.default.teardown   Default list of module names, or objects { name, config } for instantiation to use in sd-teardown


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Different bookends can be executed on different build cluster.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR changes the allows bookends to be switched for each build cluster.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- Issues
  - https://github.com/screwdriver-cd/screwdriver/issues/2763

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
