### PR TITLE
feat(2763): execute different bookends on different build cluster. BREAKING CHANGE: change constructor arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:screwdriver-cd/build-bookend.git"
+    "url": "git+https://github.com/screwdriver-cd/build-bookend.git"
   },
   "homepage": "https://github.com/screwdriver-cd/build-bookend",
   "bugs": "https://github.com/screwdriver-cd/screwdriver/issues",
@@ -41,9 +41,6 @@
   },
   "dependencies": {},
   "release": {
-    "debug": false,
-    "verifyConditions": {
-      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
-    }
+    "debug": false
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
   "name": "screwdriver-build-bookend",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "creates setup and teardown steps for builds",
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Context

Current semantic release is broken: https://cd.screwdriver.cd/pipelines/29/builds/827050/steps/publish

## Objective

This PR is a second attempt at bumping major.

## References

Related to https://github.com/screwdriver-cd/build-bookend/pull/18

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
