### PR TITLE
fix: Repo url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:screwdriver-cd/build-bookend.git"
+    "url": "git+https://github.com/screwdriver-cd/build-bookend.git"
   },
   "homepage": "https://github.com/screwdriver-cd/build-bookend",
   "bugs": "https://github.com/screwdriver-cd/screwdriver/issues",


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Semantic release is failing:

```
The authenticity of host 'github.com (192.30.255.113)' can't be established.
ECDSA key fingerprint is SHA256:xxx
(Are you sure you want to continue connecting (yes/no)?)
```

https://cd.screwdriver.cd/pipelines/29/builds/827055/steps/publish

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR fixes checkout URL for repo.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Related to https://github.com/screwdriver-cd/build-bookend/pull/20

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
