### PR TITLE
feat(#2852): implement new bookend configuration and key mapping

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@
 
 'use strict';
 
+const Hoek = require('@hapi/hoek');
+
 /**
  * Tries to load an instantiate a module
  * @method loadModule
@@ -125,28 +127,22 @@ function traverseBookends(config, defaultModules) {
  * @param  {string} bookendKey Bookend key name
  * @returns Bookend object for given key and default if key is not found
  */
-function selectBookends(bookends, bookendKey) {
+
+const selectBookends = (bookendKey, bookends) => {
     const keys = bookendKey.split('.');
     let current = bookends;
 
     for (const key of keys) {
-        const child = current[key];
+        const result = Hoek.reach(current, key, { default: Hoek.reach(current, 'default') });
 
-        if (child && key !== 'default') {
-            current = child;
-        } else {
-            const defaultKey = current.default;
-
-            if (defaultKey) {
-                current = typeof defaultKey === 'string' ? current[defaultKey] : defaultKey;
-            } else {
-                return null;
-            }
+        if (result.setupList && result.teardownList) {
+            return result;
         }
+        current = result;
     }
 
-    return current;
-}
+    return null;
+};
 
 /**
  * Defines the API for a bookend plugin

--- a/index.js
+++ b/index.js
@@ -77,8 +77,8 @@ function initializeBookend(defaultModules, cachedModules, list) {
 
 /**
  *
- * @param {Object} config
- * @param {Object} defaultModules
+ * @param {Object} config Object keyed by cluster name with value setup/teardown bookend.
+ * @param {Object} defaultModules key->instantiated plugin for default plugins provided by screwdriver-cd
  * @returns bookend object with the modules initialized
  */
 function traverseBookends(config, defaultModules) {
@@ -121,13 +121,13 @@ function traverseBookends(config, defaultModules) {
 
 /**
  *
- * @param {Object} config
- * @param  {string} bookendKey
+ * @param {Object} bookends Object keyed by cluster name with value setup/teardown bookend.
+ * @param  {string} bookendKey Bookend key name
  * @returns Bookend object for given key and default if key is not found
  */
-function selectBookends(config, bookendKey) {
+function selectBookends(bookends, bookendKey) {
     const keys = bookendKey.split('.');
-    let current = config;
+    let current = bookends;
 
     for (const key of keys) {
         const child = current[key];

--- a/index.js
+++ b/index.js
@@ -129,10 +129,10 @@ function traverseBookends(config, defaultModules) {
  * @returns Bookend object for given key and default if key is not found
  */
 const selectBookends = (bookends, bookendKey) => {
-    const keys = bookendKey.split('.');
+    const { cluster, env, executor } = bookendKey;
     let current = bookends;
 
-    for (const key of keys) {
+    for (const key of [cluster, env, executor]) {
         const result = Hoek.reach(current, key, { default: Hoek.reach(current, 'default') });
 
         if (result.setupList && result.teardownList) {
@@ -194,11 +194,11 @@ class Bookend extends BookendInterface {
      * @param  {PipelineModel}  o.pipeline    Pipeline model for the build
      * @param  {JobModel}       o.job         Job model for the build
      * @param  {Object}         o.build       Build configuration for the build (before creation)
-     * @param  {String}         [bookendKeyName] Bookend key name
+     * @param  {String}         [bookendKey]  Bookend key - { cluster, env, executor }
      * @return {Promise}
      */
-    getSetupCommands(o, bookendKeyName = 'default') {
-        const bookends = selectBookends(this.bookends, bookendKeyName) || this.bookends.default;
+    getSetupCommands(o, bookendKey = { cluster: 'default' }) {
+        const bookends = selectBookends(this.bookends, bookendKey) || this.bookends.default;
 
         return Promise.all(
             bookends.setupList.map(m => {
@@ -217,11 +217,11 @@ class Bookend extends BookendInterface {
      * @param  {PipelineModel}  o.pipeline    Pipeline model for the build
      * @param  {JobModel}       o.job         Job model for the build
      * @param  {Object}         o.build       Build configuration for the build (before creation)
-     * @param  {String}         [bookendKeyName] Bookend key name
+     * @param  {Object}         [bookendKey]  Bookend key - { cluster, env, executor }
      * @return {Promise}
      */
-    getTeardownCommands(o, bookendKeyName = 'default') {
-        const bookends = selectBookends(this.bookends, bookendKeyName) || this.bookends.default;
+    getTeardownCommands(o, bookendKey = { cluster: 'default' }) {
+        const bookends = selectBookends(this.bookends, bookendKey) || this.bookends.default;
 
         return Promise.all(
             bookends.teardownList.map(m =>

--- a/index.js
+++ b/index.js
@@ -198,8 +198,6 @@ class Bookend extends BookendInterface {
      * @return {Promise}
      */
     getSetupCommands(o, bookendKeyName = 'default') {
-        console.log(o, bookendKeyName);
-
         const bookends = selectBookends(this.bookends, bookendKeyName) || this.bookends.default;
 
         return Promise.all(

--- a/index.js
+++ b/index.js
@@ -39,11 +39,11 @@ function loadModule(config) {
  * Initializes plugins for bookend
  * @method initializeBookend
  * @param  {Array}           defaultModules List of default plugins
- * @param  {Array}           list List of plugins, or plugin configs
  * @param  {Array}           cachedModules of cached plugins
+ * @param  {Array}           list List of plugins, or plugin configs
  * @return {Array}           List of initialized plugins
  */
-function initializeBookend(defaultModules, list, cachedModules) {
+function initializeBookend(defaultModules, cachedModules, list) {
     return list.map(m => {
         let name;
         let alias;

--- a/index.js
+++ b/index.js
@@ -38,11 +38,12 @@ function loadModule(config) {
 /**
  * Initializes plugins for bookend
  * @method initializeBookend
- * @param  {Array}          list List of plugins, or plugin configs
- * @param  {Array}           list List of cached plugins
- * @return {Array}               List of initialized plugins
+ * @param  {Array}           defaultModules List of default plugins
+ * @param  {Array}           list List of plugins, or plugin configs
+ * @param  {Array}           cachedModules of cached plugins
+ * @return {Array}           List of initialized plugins
  */
-function initializeBookend(defaultModules, cachedModules, list) {
+function initializeBookend(defaultModules, list, cachedModules) {
     return list.map(m => {
         let name;
         let alias;
@@ -124,11 +125,10 @@ function traverseBookends(config, defaultModules) {
 /**
  *
  * @param {Object} bookends Object keyed by cluster name with value setup/teardown bookend.
- * @param  {string} bookendKey Bookend key name
+ * @param  {String} bookendKey Bookend key name
  * @returns Bookend object for given key and default if key is not found
  */
-
-const selectBookends = (bookendKey, bookends) => {
+const selectBookends = (bookends, bookendKey) => {
     const keys = bookendKey.split('.');
     let current = bookends;
 
@@ -198,6 +198,8 @@ class Bookend extends BookendInterface {
      * @return {Promise}
      */
     getSetupCommands(o, bookendKeyName = 'default') {
+        console.log(o, bookendKeyName);
+
         const bookends = selectBookends(this.bookends, bookendKeyName) || this.bookends.default;
 
         return Promise.all(

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "mockery": "^2.1.0",
     "nyc": "^15.1.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@hapi/hoek": "^11.0.2"
+  },
   "release": {
     "branches": [
       "master"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -243,7 +243,7 @@ describe('bookend', () => {
 
                 const b = new Bookend(defaultModules, bookends);
 
-                return b.getSetupCommands({}, 'clusterA').then(commands => {
+                return b.getSetupCommands({}, { cluster: 'clusterA' }).then(commands => {
                     assert.deepEqual(commands, [
                         {
                             name: 'sd-setup-greeting',
@@ -366,7 +366,7 @@ describe('bookend', () => {
 
                 const b = new Bookend(defaultModules, bookends);
 
-                return b.getTeardownCommands({}, 'clusterA').then(commands => {
+                return b.getTeardownCommands({}, { cluster: 'clusterA' }).then(commands => {
                     assert.deepEqual(commands, [
                         {
                             name: 'sd-teardown-greeting',
@@ -514,7 +514,7 @@ describe('nested bookends configuration', () => {
         it('should get a list of commands from clusterB.beta.k8s bookend', () => {
             const b = new Bookend(defaultModules, nestedBookends);
 
-            return b.getSetupCommands({}, 'clusterB.beta.k8s').then(commands => {
+            return b.getSetupCommands({}, { cluster: 'clusterB', env: 'beta', executor: 'k8s' }).then(commands => {
                 assert.deepEqual(commands, [
                     {
                         name: 'sd-setup-yoda',
@@ -530,7 +530,7 @@ describe('nested bookends configuration', () => {
         it('should get a list of commands from clusterB.beta.k8s bookend', () => {
             const b = new Bookend(defaultModules, nestedBookends);
 
-            return b.getSetupCommands({}, 'clusterB.beta.k8s').then(commands => {
+            return b.getSetupCommands({}, { cluster: 'clusterB', env: 'beta', executor: 'k8s' }).then(commands => {
                 assert.deepEqual(commands, [
                     {
                         name: 'sd-setup-yoda',
@@ -546,16 +546,16 @@ describe('nested bookends configuration', () => {
         it('should get a list of commands from clusterB.beta.default bookend', async () => {
             const b = new Bookend(defaultModules, nestedBookends);
 
-            const expected = await b.getSetupCommands({}, 'clusterB.beta.default');
-            const actual = await b.getSetupCommands({}, 'clusterB.beta.k8s');
+            const expected = await b.getSetupCommands({}, { cluster: 'clusterB', env: 'beta', executor: 'default' });
+            const actual = await b.getSetupCommands({}, { cluster: 'clusterB', env: 'beta', executor: 'k8s' });
 
             assert.deepEqual(expected, actual);
         });
         it('should get a list of commands from clusterB.us-west-2.sls bookend', async () => {
             const b = new Bookend(defaultModules, nestedBookends);
 
-            const expected = await b.getSetupCommands({}, 'clusterB.us-west-2.sls');
-            const actual = await b.getSetupCommands({}, 'clusterB.beta.sls');
+            const expected = await b.getSetupCommands({}, { cluster: 'clusterB', env: 'us-west-2', executor: 'sls' });
+            const actual = await b.getSetupCommands({}, { cluster: 'clusterB', env: 'beta', executor: 'k8s-arm' });
 
             assert.deepEqual(expected, actual);
         });
@@ -565,7 +565,7 @@ describe('nested bookends configuration', () => {
         it('should get a list of commands from clusterB.beta.k8s bookend', () => {
             const b = new Bookend(defaultModules, nestedBookends);
 
-            return b.getTeardownCommands({}, 'clusterB.beta.k8s').then(commands => {
+            return b.getTeardownCommands({}, { cluster: 'clusterB', env: 'beta', executor: 'k8s' }).then(commands => {
                 assert.deepEqual(commands, [
                     {
                         name: 'sd-teardown-yoda',
@@ -581,8 +581,11 @@ describe('nested bookends configuration', () => {
         it('should get a list of commands from clusterB.us-west-2.k8s-arm bookend', async () => {
             const b = new Bookend(defaultModules, nestedBookends);
 
-            const expected = await b.getTeardownCommands({}, 'clusterB.us-west-2.k8s-arm');
-            const actual = await b.getTeardownCommands({}, 'clusterB.beta.k8s-arm');
+            const expected = await b.getTeardownCommands(
+                {},
+                { cluster: 'clusterB', env: 'us-west-2', executor: 'k8s-arm' }
+            );
+            const actual = await b.getTeardownCommands({}, { cluster: 'clusterB', env: 'beta', executor: 'k8s-arm' });
 
             assert.deepEqual(expected, actual);
         });
@@ -590,8 +593,8 @@ describe('nested bookends configuration', () => {
         it('should get a list of commands from clusterB.beta.default bookend', async () => {
             const b = new Bookend(defaultModules, nestedBookends);
 
-            const expected = await b.getTeardownCommands({}, 'clusterB.beta.default');
-            const actual = await b.getTeardownCommands({}, 'clusterB.beta.k8s');
+            const expected = await b.getTeardownCommands({}, { cluster: 'clusterB', env: 'beta', executor: 'default' });
+            const actual = await b.getTeardownCommands({}, { cluster: 'clusterB', env: 'beta', executor: 'k8s' });
 
             assert.deepEqual(expected, actual);
         });


### PR DESCRIPTION
## Context

Bookend configuration needs to be flexible and aware of the environment  and executor to pick the correct set of bookends

## Objective

This PR adds logic to select bookends by a key name which comprises of `cluster_name.env_name.executor_name`
and defaults to build cluster name or default configuration

## References

[<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->](https://github.com/screwdriver-cd/screwdriver/issues/2852)

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
